### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/812/27/85681227.geojson
+++ b/data/856/812/27/85681227.geojson
@@ -123,7 +123,7 @@
     "qs:type":"Admin-1 aggregation",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "uscensus-display-terrestrial-zoom-10"
+        "uscensus"
     ],
     "src:lbl:centroid":"mapshaper",
     "wd:wordcount":8355,
@@ -142,6 +142,9 @@
         "wd:id":"Q16635"
     },
     "wof:country":"GU",
+    "wof:geom_alt":[
+        "uscensus-display-terrestrial-zoom-10"
+    ],
     "wof:geomhash":"d6ed07ec96ced54ec6112044630b7e78",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         "eng",
         "cha"
     ],
-    "wof:lastmodified":1536616805,
+    "wof:lastmodified":1582317863,
     "wof:name":"Guam",
     "wof:parent_id":85632163,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.