### PR TITLE
GU concordances, placetype local, and more

### DIFF
--- a/data/421/171/953/421171953.geojson
+++ b/data/421/171/953/421171953.geojson
@@ -21,7 +21,7 @@
     ],
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
@@ -63,11 +63,13 @@
     "wof:concordances":{
         "gn:id":4038652,
         "gp:id":24549712,
+        "iso:code_pseudo":"GU",
         "qs_pg:id":1287880
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"GU",
     "wof:created":1459008913,
-    "wof:geomhash":"d8c1f16ee62068cbd6f6dcb51adff891",
+    "wof:geomhash":"e1699bb6757af39ffff475565ce494d7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -86,7 +88,7 @@
         "eng",
         "cha"
     ],
-    "wof:lastmodified":1627522161,
+    "wof:lastmodified":1695884283,
     "wof:name":"Talofofo",
     "wof:parent_id":85632163,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.